### PR TITLE
Fix the calculation of reserved nodes for ElastiCache

### DIFF
--- a/src/check_reserved_instances/aws.py
+++ b/src/check_reserved_instances/aws.py
@@ -185,7 +185,7 @@ def calculate_elc_ris(session, results):
                 results['elc_running_instances'][(
                     instance_type, engine)] = results[
                     'elc_running_instances'].get(
-                        (instance_type, engine), 0) + 1
+                        (instance_type, engine), 0) + instance['NumCacheNodes']
                 instance_ids[(instance_type, engine)].append(
                     instance['CacheClusterId'])
 

--- a/tests/test_calculate.py
+++ b/tests/test_calculate.py
@@ -273,12 +273,14 @@ def get_elc_instances():
                 'Engine': 'redis',
                 'CacheNodeType': 'cache.t2.small',
                 'CacheClusterId': 'test1',
+                'NumCacheNodes': 2,
             },
             {
                 'CacheClusterStatus': 'stopped',
                 'Engine': 'redis',
                 'CacheNodeType': 'cache.m3.medium',
                 'CacheClusterId': 'test2',
+                'NumCacheNodes': 1,
             }
         ]
     }


### PR DESCRIPTION
The ElastiCache report was comparing the number of reserved nodes to the
number of clusters, rather than to the number of nodes. This meant that
any cluster with more than one reserved node appeared appeared to lack
reservations, leading to much confusion.

Rather than counting each cluster toward the reservation, each cluster's
node is now counted instead.